### PR TITLE
enabled use of different independent_vars...

### DIFF
--- a/lmfit/model.py
+++ b/lmfit/model.py
@@ -1094,7 +1094,7 @@ class CompositeModel(Model):
 
         Notes
         -----
-        The two models must use the same independent variable.
+        The two models can use different independent variables.
 
         """
         if not isinstance(left, Model):
@@ -1116,9 +1116,9 @@ class CompositeModel(Model):
                         "use distinct names.")
             raise NameError(msg)
 
-        # we assume that all the sub-models have the same independent vars
+        # every independent_vars of the left and right model is added to independent_vars of the CompositeModel
         if 'independent_vars' not in kws:
-            kws['independent_vars'] = self.left.independent_vars
+            kws['independent_vars'] = list(dict.fromkeys([*self.left.independent_vars, *self.right.independent_vars]))
         if 'nan_policy' not in kws:
             kws['nan_policy'] = self.left.nan_policy
 


### PR DESCRIPTION
... in Composite Model
The independent_vars in the CompositeModel are now no longer only the independent_vars of the left model. 
Now, the independent_vars of the left model and right model are both passed to the independent_vars of the CompositeModel.
To reach that, I simply changed l.1120 in `model.py` from:
I think it should be fixed by changing l. 1120 in `model.py` from:

```
if 'independent_vars' not in kws:

    kws['independent_vars'] = self.left.independent_vars
```
to :

```      
if 'independent_vars' not in kws:

    kws['independent_vars'] = list(dict.fromkeys([*self.left.independent_vars, *self.right.independent_vars]))
```

This fix solves the problem described in [detail here](https://github.com/lmfit/lmfit-py/discussions/787).




###### Type of Changes
- [x] Bug fix
- [x] New feature
- [ ] Refactoring / maintenance
- [ ] Documentation / examples


###### Tested on
Python: 3.8.3 (default, Jul  2 2020, 16:21:59)
[GCC 7.3.0]

lmfit: 1.0.3.post31+gb930dde.d20220613, scipy: 1.5.0, numpy: 1.18.5, asteval: 0.9.26, uncertainties: 3.1.6

###### Verification 
Have you
- [x] included docstrings that follow PEP 257? --> only small modification in Docstring (CompositeModel--> NOTES)
- [x] referenced existing Issue and/or provided relevant link to mailing list?
- [x] verified that existing tests pass locally?
- [x] verified that the documentation builds locally?
- [x] squashed/minimized your commits and written descriptive commit messages?
- [ ] added or updated existing tests to cover the changes?
- [ ] updated the documentation and/or added an entry to the release notes (doc/whatsnew.rst)?
- [ ] added an example? 
